### PR TITLE
[misc] enable run as a module

### DIFF
--- a/src/llamafactory/cli.py
+++ b/src/llamafactory/cli.py
@@ -120,3 +120,6 @@ def main():
         print(USAGE)
     else:
         raise NotImplementedError(f"Unknown command: {command}.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# What does this PR do?

Right now we cannot invoke llama factory via `python` directly.

With this PR, we can use `python -m llamafactory.cli` , which is required for using debugger like vscode [debugger](https://github.com/microsoft/debugpy)

## Before submitting

- [x] Did you read the [contributor guideline](https://github.com/hiyouga/LLaMA-Factory/blob/main/.github/CONTRIBUTING.md)?
- [ ] Did you write any new necessary tests?
